### PR TITLE
Add FastAPI backend and Angular UI for video claim checker

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,18 @@
+# Backend (FastAPI)
+
+This mock backend exposes endpoints to simulate live transcript generation and claim verification for a video stream.
+
+## Running locally
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn backend.main:app --reload
+```
+
+## Endpoints
+- `POST /api/sessions` – start a session with a video URL and return a sample transcript.
+- `GET /api/sessions/{session_id}/transcript` – fetch the transcript for the session.
+- `POST /api/claims` – return mocked claim checks for the transcript (meant to be called every 10 seconds).

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,52 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from uuid import uuid4
+from typing import Dict, List
+
+from .models import ClaimCheckRequest, ClaimCheckResponse, SessionResponse, TranscriptItem, VideoSessionRequest
+from .services.claims import build_claim_response
+from .services.transcript import generate_transcript
+
+app = FastAPI(title="Video Claim Checker")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# In-memory demo store. In production, replace with persistent state.
+sessions: Dict[str, List[TranscriptItem]] = {}
+
+
+@app.post("/api/sessions", response_model=SessionResponse)
+def create_session(payload: VideoSessionRequest) -> SessionResponse:
+    """Create a new video analysis session and precompute sample transcript."""
+    if not payload.url:
+        raise HTTPException(status_code=400, detail="Video URL is required")
+
+    session_id = str(uuid4())
+    transcript = generate_transcript(payload.url)
+    sessions[session_id] = transcript
+    return SessionResponse(session_id=session_id, transcript=transcript)
+
+
+@app.get("/api/sessions/{session_id}/transcript", response_model=SessionResponse)
+def get_transcript(session_id: str) -> SessionResponse:
+    """Return the transcript for the requested session."""
+    transcript = sessions.get(session_id)
+    if transcript is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return SessionResponse(session_id=session_id, transcript=transcript)
+
+
+@app.post("/api/claims", response_model=ClaimCheckResponse)
+def check_claims(payload: ClaimCheckRequest) -> ClaimCheckResponse:
+    """Mock claim validation against the transcript snapshot."""
+    transcript = sessions.get(payload.session_id)
+    if transcript is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    return build_claim_response(payload.session_id, transcript, payload.window_start_seconds)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,33 @@
+from typing import List, Optional
+from pydantic import BaseModel, HttpUrl
+
+
+class TranscriptItem(BaseModel):
+    timestamp: float
+    text: str
+
+
+class VideoSessionRequest(BaseModel):
+    url: HttpUrl
+
+
+class SessionResponse(BaseModel):
+    session_id: str
+    transcript: List[TranscriptItem]
+
+
+class ClaimCheckRequest(BaseModel):
+    session_id: str
+    window_start_seconds: Optional[float] = None
+
+
+class ClaimEvidence(BaseModel):
+    timestamp: float
+    text: str
+    verdict: str
+    confidence: float
+
+
+class ClaimCheckResponse(BaseModel):
+    session_id: str
+    claims: List[ClaimEvidence]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.111.0
+uvicorn[standard]==0.30.0
+pydantic==1.10.14

--- a/backend/services/claims.py
+++ b/backend/services/claims.py
@@ -1,0 +1,34 @@
+import random
+from typing import List
+
+from ..models import ClaimCheckResponse, ClaimEvidence, TranscriptItem
+
+CLAIM_LIBRARY = [
+    ("Solar panels only work in direct sunlight", False),
+    ("Wind energy is a type of renewable energy", True),
+    ("Battery storage smooths out renewable intermittency", True),
+    ("Renewables cannot contribute to grid stability", False),
+    ("Energy efficiency can lower consumption", True),
+]
+
+
+def build_claim_response(
+    session_id: str, transcript: List[TranscriptItem], window_start: float | None
+) -> ClaimCheckResponse:
+    """Return a deterministic yet varied claim verdict for the provided transcript slice."""
+    relevant = [item for item in transcript if window_start is None or item.timestamp >= window_start]
+    claims: List[ClaimEvidence] = []
+
+    for idx, item in enumerate(relevant):
+        claim_text, truth_value = CLAIM_LIBRARY[idx % len(CLAIM_LIBRARY)]
+        confidence = round(random.uniform(0.6, 0.98), 2)
+        claims.append(
+            ClaimEvidence(
+                timestamp=item.timestamp,
+                text=claim_text,
+                verdict="true" if truth_value else "false",
+                confidence=confidence,
+            )
+        )
+
+    return ClaimCheckResponse(session_id=session_id, claims=claims)

--- a/backend/services/transcript.py
+++ b/backend/services/transcript.py
@@ -1,0 +1,23 @@
+from typing import List
+
+from ..models import TranscriptItem
+
+# Sample text blocks to mimic a streaming transcript.
+TRANSCRIPT_SNIPPETS = [
+    "Welcome to our exploration of sustainable energy.",
+    "Solar panels convert sunlight directly into electricity.",
+    "Some people believe solar panels only work in direct sunlight, but they also generate power on cloudy days.",
+    "Wind turbines harness kinetic energy from the wind and feed it into the grid.",
+    "Battery storage helps balance supply and demand by storing excess energy for later.",
+    "Critics sometimes claim renewable energy is too unreliable, yet modern grids blend multiple sources to stay stable.",
+    "Energy efficiency measures can reduce household consumption by up to 30 percent.",
+    "Policy incentives and innovation keep driving renewable adoption worldwide.",
+]
+
+
+def generate_transcript(url: str) -> List[TranscriptItem]:
+    """Return a mocked transcript timeline for the provided video URL."""
+    transcript: List[TranscriptItem] = []
+    for index, snippet in enumerate(TRANSCRIPT_SNIPPETS):
+        transcript.append(TranscriptItem(timestamp=float(index * 10), text=snippet))
+    return transcript

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,13 @@
+# Frontend (Angular)
+
+A lightweight Angular UI that lets users paste a video URL, view a preview, and watch live transcript and claim-check updates.
+
+## Setup
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+The app expects the FastAPI server to run at `http://localhost:8000`. Update `src/environments/environment.ts` to point to a different host if needed.

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular/cli/lib/config/schema.json",
+  "version": 1,
+  "projects": {
+    "video-claim-checker": {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/video-claim-checker",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": [],
+            "tsConfig": "tsconfig.app.json",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "video-claim-checker:build"
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "video-claim-checker"
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "video-claim-checker",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "ng serve --open",
+    "build": "ng build"
+  },
+  "dependencies": {
+    "@angular/animations": "17.3.0",
+    "@angular/common": "17.3.0",
+    "@angular/compiler": "17.3.0",
+    "@angular/core": "17.3.0",
+    "@angular/forms": "17.3.0",
+    "@angular/platform-browser": "17.3.0",
+    "@angular/platform-browser-dynamic": "17.3.0",
+    "@angular/router": "17.3.0",
+    "rxjs": "7.8.1",
+    "zone.js": "0.14.4"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "17.3.4",
+    "@angular/cli": "17.3.4",
+    "@angular/compiler-cli": "17.3.0",
+    "typescript": "5.4.5"
+  }
+}

--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -1,0 +1,159 @@
+:host {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  color: #0f172a;
+  display: block;
+  padding: 24px;
+  background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
+  min-height: 100vh;
+}
+
+.layout header {
+  margin-bottom: 16px;
+}
+
+.layout h1 {
+  margin: 0 0 8px 0;
+  font-size: 28px;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  margin-bottom: 16px;
+}
+
+.controls input {
+  flex: 1;
+  padding: 10px 12px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  font-size: 14px;
+}
+
+.controls button {
+  background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+  color: #fff;
+  border: none;
+  padding: 10px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.controls .status {
+  font-size: 12px;
+  color: #475569;
+}
+
+.content {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+@media (min-width: 960px) {
+  .content {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}
+
+.player {
+  background: #0f172a;
+  border-radius: 12px;
+  min-height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: inset 0 0 0 1px #1e293b, 0 10px 30px rgba(15, 23, 42, 0.3);
+}
+
+.player video {
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
+}
+
+.panel {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 12px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.panel-header button {
+  border: none;
+  background: #e0e7ff;
+  color: #4338ca;
+  padding: 8px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.items {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.item {
+  background: #f8fafc;
+  border-radius: 8px;
+  padding: 8px;
+  border: 1px solid #e2e8f0;
+}
+
+.timestamp {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.text {
+  margin-top: 4px;
+}
+
+.badge {
+  margin-top: 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.badge.true {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.badge.false {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.placeholder {
+  color: #94a3b8;
+}

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,0 +1,49 @@
+<div class="layout">
+  <header>
+    <h1>Video Claim Checker</h1>
+    <p>Paste a video URL, play it, and watch live claim verification results.</p>
+  </header>
+
+  <section class="controls">
+    <label for="videoUrl">Video URL</label>
+    <input id="videoUrl" name="videoUrl" [(ngModel)]="videoUrl" placeholder="https://example.com/video.mp4" />
+    <button (click)="startSession()">Start session</button>
+    <span class="status">{{ statusMessage }}</span>
+  </section>
+
+  <section class="content">
+    <div class="player">
+      <video controls [src]="videoUrl" *ngIf="videoUrl"></video>
+      <p *ngIf="!videoUrl" class="placeholder">Video preview will appear here.</p>
+    </div>
+
+    <div class="panel transcript">
+      <div class="panel-header">
+        <h2>Live transcript</h2>
+        <button (click)="fetchTranscript()" [disabled]="!sessionId">Refresh</button>
+      </div>
+      <div class="items">
+        <div *ngFor="let item of transcript" class="item">
+          <div class="timestamp">{{ item.timestamp | number: '1.0-0' }}s</div>
+          <div class="text">{{ item.text }}</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel claims">
+      <div class="panel-header">
+        <h2>Claim checks (10s cadence)</h2>
+      </div>
+      <div class="items">
+        <div *ngFor="let claim of claims" class="item">
+          <div class="timestamp">{{ claim.timestamp | number: '1.0-0' }}s</div>
+          <div class="text">{{ claim.text }}</div>
+          <div class="badge" [class.true]="claim.verdict === 'true'" [class.false]="claim.verdict === 'false'">
+            {{ claim.verdict | uppercase }} · {{ claim.confidence | percent: '1.0-0' }}
+          </div>
+        </div>
+        <p *ngIf="!claims.length" class="placeholder">No claim checks yet. They will appear every 10 seconds.</p>
+      </div>
+    </div>
+  </section>
+</div>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,0 +1,88 @@
+import { Component, OnDestroy } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { interval, Subscription } from 'rxjs';
+import { environment } from '../environments/environment';
+
+interface TranscriptItem {
+  timestamp: number;
+  text: string;
+}
+
+interface SessionResponse {
+  session_id: string;
+  transcript: TranscriptItem[];
+}
+
+interface ClaimEvidence {
+  timestamp: number;
+  text: string;
+  verdict: string;
+  confidence: number;
+}
+
+interface ClaimCheckResponse {
+  session_id: string;
+  claims: ClaimEvidence[];
+}
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css']
+})
+export class AppComponent implements OnDestroy {
+  videoUrl = '';
+  sessionId = '';
+  transcript: TranscriptItem[] = [];
+  claims: ClaimEvidence[] = [];
+  statusMessage = 'Enter a video URL to begin.';
+  private pollSub?: Subscription;
+
+  constructor(private http: HttpClient) {}
+
+  ngOnDestroy(): void {
+    this.pollSub?.unsubscribe();
+  }
+
+  startSession(): void {
+    if (!this.videoUrl) {
+      this.statusMessage = 'Please provide a video URL.';
+      return;
+    }
+
+    this.statusMessage = 'Starting session and fetching transcript...';
+    this.http
+      .post<SessionResponse>(`${environment.apiBaseUrl}/api/sessions`, { url: this.videoUrl })
+      .subscribe((session) => {
+        this.sessionId = session.session_id;
+        this.transcript = session.transcript;
+        this.statusMessage = 'Live transcript ready. Claim checks will update every 10 seconds.';
+        this.startClaimPolling();
+      });
+  }
+
+  private startClaimPolling(): void {
+    this.pollSub?.unsubscribe();
+    this.pollSub = interval(10000).subscribe(() => this.fetchClaims());
+    this.fetchClaims();
+  }
+
+  fetchTranscript(): void {
+    if (!this.sessionId) return;
+    this.http
+      .get<SessionResponse>(`${environment.apiBaseUrl}/api/sessions/${this.sessionId}/transcript`)
+      .subscribe((session) => (this.transcript = session.transcript));
+  }
+
+  fetchClaims(): void {
+    if (!this.sessionId) return;
+    this.http
+      .post<ClaimCheckResponse>(`${environment.apiBaseUrl}/api/claims`, {
+        session_id: this.sessionId,
+        window_start_seconds: this.transcript.length ? this.transcript[0].timestamp : 0
+      })
+      .subscribe((response) => {
+        this.claims = response.claims;
+      });
+  }
+}

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule, FormsModule, HttpClientModule],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiBaseUrl: 'http://localhost:8000'
+};

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Video Claim Checker</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,6 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch((err) => console.error(err));

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,8 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #f8fafc;
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*.d.ts"],
+  "exclude": ["src/test.ts", "**/*.spec.ts"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es2022",
+    "module": "es2022",
+    "useDefineForClassFields": false,
+    "lib": ["es2022", "dom"]
+  }
+}


### PR DESCRIPTION
## Summary
- create FastAPI backend endpoints to mock transcript generation and claim validation for video URLs
- scaffold Angular UI to input video URLs, preview playback, and poll for transcript and claim results
- add setup docs for both backend and frontend

## Testing
- python -m compileall backend

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b13c7b384832cb47d91b806401fd1)